### PR TITLE
Replace `result.nil_error` with `result.replace_error(Nil)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Changed deprecated result.nil_error to result.replace_error(Nil)
-
 ## [0.1.0] - 2024-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Changed deprecated result.nil_error to result.replace_error(Nil)
+
 ## [0.1.0] - 2024-05-29
 
 ### Added

--- a/src/aragorn2.gleam
+++ b/src/aragorn2.gleam
@@ -103,7 +103,7 @@ pub fn with_hash_length(hasher: Hasher, hash_length: Int) -> Hasher {
 /// Returns the hash of the given password.
 pub fn hash_password(hasher: Hasher, password: BitArray) -> Result(String, Nil) {
   do_hash_password(hasher, password)
-  |> result.nil_error
+  |> result.replace_error(Nil)
 }
 
 @external(erlang, "aragorn2_ffi", "hash_password")
@@ -117,7 +117,7 @@ pub fn verify_password(
 ) -> Result(Nil, Nil) {
   do_verify_password(hasher, candidate_password, hashed_password)
   |> result.map(fn(_) { Nil })
-  |> result.nil_error
+  |> result.replace_error(Nil)
 }
 
 @external(erlang, "aragorn2_ffi", "verify_password")


### PR DESCRIPTION
result.nil_error() was deprecated from gleam_stdlib 